### PR TITLE
オプションページを仮実装

### DIFF
--- a/src/core.css
+++ b/src/core.css
@@ -1,4 +1,4 @@
-body {
+body[theme="light"] {
     --color-background-main: #f4f5f7;
     --color-background-theme: #e8f5e9;
     --color-title-2: #1b5e20;
@@ -22,49 +22,47 @@ body {
     background: var(--color-background-main) !important;
 }
 
-/*
-@media screen and (prefers-color-scheme: dark) {
-    body {
-        --color-background-main: #000a12;
-        --color-background-theme: #445963;
-        --color-title-2: #dcedc8;
-        --color-title-3: #aed681;
-        --color-text-disabled: #c1c1c1;
-        --color-card-shadow: #000000;
-        --color-card-background: #102027;
-        --color-card-border-white: #445963;
-        --color-card-background-alert: #ffebee;
-        --color-card-border-alert: #ccb9bc;
-        --color-card-background-memo: #fff9c4;
-        --color-card-border-memo: #cccab5;
-        --color-menubar-background: #102027;
-        --color-menubar-hover: #66bb6a;
-        --color-table-grade-bar: #2e7d32;
-        --color-table-border: #000a12;
-        --color-table-border-2: #eeeeee;
-        --color-unreadcount-background: #ef5350;
-        --color-default-font: #ffffff;
+body[theme="dark"] {
+    --color-background-main: #000a12;
+    --color-background-theme: #445963;
+    --color-title-2: #dcedc8;
+    --color-title-3: #aed681;
+    --color-text-disabled: #c1c1c1;
+    --color-card-shadow: #000000;
+    --color-card-background: #102027;
+    --color-card-border-white: #445963;
+    --color-card-background-alert: #ffebee;
+    --color-card-border-alert: #ccb9bc;
+    --color-card-background-memo: #fff9c4;
+    --color-card-border-memo: #cccab5;
+    --color-menubar-background: #102027;
+    --color-menubar-hover: #66bb6a;
+    --color-table-grade-bar: #2e7d32;
+    --color-table-border: #000a12;
+    --color-table-border-2: #eeeeee;
+    --color-unreadcount-background: #ef5350;
+    --color-default-font: #ffffff;
 
-        color: #f4f4f4 !important;
+    color: #f4f4f4 !important;
 
-        background: var(--color-background-main) !important;
-    }
-
-    a {
-        color: #baddf9 !important;
-    }
-
-    .course-card-title a {
-        background-color: transparent !important;
-    }
-
-
-    .pagebody .section .coursecard:hover a {
-        background-color: transparent !important;
-    }
-    
+    background: var(--color-background-main) !important;
 }
-*/
+
+body[theme="dark"] a {
+    color: #baddf9 !important;
+}
+
+body[theme="dark"] .course-card-title a {
+    background-color: transparent !important;
+}
+
+body[theme="dark"] .alertlist a {
+    color: red !important;
+}
+
+body[theme="dark"] .pagebody .section .coursecard:hover a {
+    background-color: transparent !important;
+}
 
 .pagebody, .home {
     width: 100% !important;

--- a/src/header.css
+++ b/src/header.css
@@ -1,4 +1,4 @@
-body {
+body[theme="light"] {
     --color-background-main: #f4f5f7;
     --color-background-theme: #e8f5e9;
     --color-title-2: #1b5e20;
@@ -22,44 +22,41 @@ body {
     background: var(--color-background-main) !important;
 }
 
-/*
-@media screen and (prefers-color-scheme: dark) {
-    body {
-        --color-background-main: #000a12;
-        --color-background-theme: #445963;
-        --color-title-2: #dcedc8;
-        --color-title-3: #aed681;
-        --color-text-disabled: #c1c1c1;
-        --color-card-shadow: #000000;
-        --color-card-background: #102027;
-        --color-card-border-white: #445963;
-        --color-card-background-alert: #ffebee;
-        --color-card-border-alert: #ccb9bc;
-        --color-card-background-memo: #fff9c4;
-        --color-card-border-memo: #cccab5;
-        --color-menubar-background: #102027;
-        --color-menubar-hover: #66bb6a;
-        --color-table-grade-bar: #2e7d32;
-        --color-table-border: #000a12;
-        --color-unreadcount-background: #ef5350;
 
-        --school-header-image: url('chrome-extension://__MSG_@@extension_id__/images/header-school-dark.gif');
+body[theme="dark"] {
+    --color-background-main: #000a12;
+    --color-background-theme: #445963;
+    --color-title-2: #dcedc8;
+    --color-title-3: #aed681;
+    --color-text-disabled: #c1c1c1;
+    --color-card-shadow: #000000;
+    --color-card-background: #102027;
+    --color-card-border-white: #445963;
+    --color-card-background-alert: #ffebee;
+    --color-card-border-alert: #ccb9bc;
+    --color-card-background-memo: #fff9c4;
+    --color-card-border-memo: #cccab5;
+    --color-menubar-background: #102027;
+    --color-menubar-hover: #66bb6a;
+    --color-table-grade-bar: #2e7d32;
+    --color-table-border: #000a12;
+    --color-unreadcount-background: #ef5350;
 
-        color: #f4f4f4 !important;
+    --school-header-image: url('chrome-extension://__MSG_@@extension_id__/images/header-school-dark.gif');
+
+    color: #f4f4f4 !important;
 
 
-        background: var(--color-background-main) !important;
-    }
-
-    a {
-        color: #baddf9 !important;
-    }
-    
-    .pagefooter {
-    background-image: url(chrome-extension://__MSG_@@extension_id__/images/bg-footerV3-dark.png) !important;
-  }
+    background: var(--color-background-main) !important;
 }
-*/
+
+body[theme="dark"] a {
+    color: #baddf9 !important;
+}
+
+body[theme="dark"] .pagefooter {
+    background-image: url(chrome-extension://__MSG_@@extension_id__/images/bg-footerV3-dark.png) !important;
+}
 
 .pagebody {
     width: 100% !important;

--- a/src/header.js
+++ b/src/header.js
@@ -1,6 +1,15 @@
 document.documentElement.style.visibility = 'hidden';
 
+let defaults = {darkmode: false};
+
 window.onload = () => {
+
+    // オプションページから設定を読み込む
+    chrome.storage.sync.get(defaults, function(items) {
+        document.body.setAttribute('theme', 'light');
+        if(items.darkmode)  document.body.setAttribute('theme', 'dark');
+    });
+
     let mypage = document.createElement('span');
     mypage.classList.add('mynavi-button-a');
     mypage.innerHTML = 'マイページ';
@@ -212,18 +221,6 @@ window.onload = () => {
     for (let td of document.querySelectorAll("td.gradebar")) {
         td.setAttribute('style', '');
     }
-
-    const url = location.href;
-    const examPageRegex = new RegExp('https://manaba.tsukuba.ac.jp/ct/home_library_query|https://manaba\.tsukuba\.ac\.jp/ct/course_[0-9]+_(query|survey|report)');
-    // Manaba Enhancedがインストールされていて、提出期限によって色付けされるページなら
-    if (document.getElementsByClassName("mylinks-sep").length === 3 && examPageRegex.test(url)) {
-        // テーブルの背景色の変更を無効化する
-        let styleSheets = document.styleSheets;
-        let styleSheet = styleSheets[styleSheets.length - 1];
-        styleSheet.insertRule( 'table tr:nth-child(even) { background: transparent !important; }', styleSheet.cssRules.length);
-        styleSheet.insertRule( 'table tr:nth-child(odd) { background: transparent !important; }', styleSheet.cssRules.length);
-    }
-
 
     document.getElementById("mylinks");
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,6 +6,10 @@
   "web_accessible_resources": [
     "images/*"
   ],
+  "permissions": [
+    "storage"
+  ],
+  "options_page": "options/options.html",
   "content_scripts": [
     {
       "matches": [
@@ -13,8 +17,7 @@
       ],
       "exclude_matches": [
         "https://manaba.tsukuba.ac.jp/ct/usermemo_*",
-        "https://manaba.tsukuba.ac.jp/ct/doc_student",
-        "https://manaba.tsukuba.ac.jp/ct/link_iframe_balloon*"
+        "https://manaba.tsukuba.ac.jp/ct/doc_student"
       ],
       "js": [
         "header.js"

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,0 +1,106 @@
+body[theme="light"] {
+    --color-background-main: #f4f5f7;
+    --color-background-theme: #e8f5e9;
+    --color-title-2: #1b5e20;
+    --color-card-shadow: #bdbdbd;
+    --color-card-background: #ffffff;
+    --color-card-border-white: #e0e0e0;
+
+    background: var(--color-background-main);
+}
+
+body[theme="dark"] {
+    --color-background-main: #000a12;
+    --color-background-theme: #445963;
+    --color-title-2: #dcedc8;
+    --color-card-shadow: #000000;
+    --color-card-background: #102027;
+    --color-card-border-white: #445963;
+
+    color: #f4f4f4 !important;
+    background: var(--color-background-main);
+
+}
+
+h1 {
+    color: var(--color-title-2);
+}
+
+section {
+    width: 60%;
+    padding: 1.5rem;
+    padding-bottom: 100px;
+    margin: auto;
+    border-radius: 0.5rem;
+    border-color: var(--color-card-border);
+    background: var(--color-card-background);
+    box-shadow: 2px 2px 4px var(--color-card-shadow);
+}
+
+ul {
+    list-style-type: none;
+}
+
+.switch-title {
+    float: left;
+    margin-top: 5px;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    float: right;
+    width: 60px;
+    height: 34px;
+    margin-bottom: 10px;
+}
+
+.switch input { 
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+    border-radius: 34px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+    border-radius: 50%;
+}
+
+input:checked + .slider {
+    background-color: #2196F3;
+}
+
+input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+    -webkit-transform: translateX(26px);
+    -ms-transform: translateX(26px);
+    transform: translateX(26px);
+}
+
+.switch-title {
+    font-size: 1.2rem;
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Modern manaba</title>
+    <link rel="stylesheet" type="text/css" href="options.css">
+  </head>
+  <body align="center">
+    <header>
+      <h1>Modern manaba</h1>
+    </header>
+    <section class="section-options">
+      <ul class="options">
+        <li>
+          <span class="switch-title">ダークモードを適用</span>
+          <label class="switch">
+            <input type="checkbox" name="darkmode">
+            <span class="slider"></span>
+          </label>
+        </li>
+      </ul>
+      <script type="text/javascript" src="options.js"></script>
+  </body>
+</html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,0 +1,17 @@
+const triggerDarkmode = document.querySelector('input[name="darkmode"]');
+let options = {darkmode: false};
+
+chrome.storage.sync.get(options, function(items) {
+    if(items.darkmode) {
+        triggerDarkmode.checked = true;
+        document.body.setAttribute('theme', 'dark');
+    } else {
+        document.body.setAttribute('theme', 'light');
+    }
+});
+
+triggerDarkmode.addEventListener('change', function() {
+    options.darkmode = triggerDarkmode.checked;
+    chrome.storage.sync.set(options, function(){});
+    location.reload();
+});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/80367947/153537665-44ce1c26-1422-4484-83e7-457f538737ce.png)
![image](https://user-images.githubusercontent.com/80367947/153537681-82675488-d59f-42f6-bbe9-e01197766756.png)
#6 のPRです。とりあえずダークテーマに変更するためのオプションページを実装しました。それに合わせて、prefers-color-schemeを確認せずにオプションページの設定を読み込んでCSSを適用するようにしています。オプションページ自体のダークテーマも作っています。manaba enhancedのようにmanabaのページ自体にオプションページのリンクはまだ張っていないので、ブラウザの拡張機能の設定ページからオプションページを開くようになっています。
