### PR TITLE
レポート提出画面のデザインの修正

### DIFF
--- a/src/core.css
+++ b/src/core.css
@@ -698,6 +698,14 @@ table.stdlist-report tr:hover th {
     background-color: var(--color-background-main) !important;
 }
 
+div.form .report-form {
+    color: var(--color-default-font) !important;
+}
+
+div.form div.upload input {
+    color: #1b5e20 !important;
+}
+
 /*
 お知らせ
  */


### PR DESCRIPTION
#26 の修正。すっかり忘れていた... 修正して以下のようになりました:
![image](https://user-images.githubusercontent.com/80367947/173169047-ceeaad9a-dee9-4129-992e-7b2c683364e6.png)
